### PR TITLE
Fix text input in demo-02

### DIFF
--- a/demo-02/tweet.js
+++ b/demo-02/tweet.js
@@ -18,9 +18,10 @@ const { chromium, webkit, devices } = require('playwright');
     await page.fill('input[type="password"]', '<include-password>');
     await page.click('div[data-testid="LoginForm_Login_Button"]')
 
-   // Agora vamos fazer um tweet automatizado usando o Playwright:
+    // Agora vamos fazer um tweet automatizado usando o Playwright:
 
-    await page.fill('.public-DraftStyleDefault-ltr', 'Realizando um tweet automatizado, utilizando a ferramenta de Testes do Playwright - Demo em breve e tutorial sobre o assunto! 😎 (Link: https://playwright.dev/)');
+    await page.click('.public-DraftStyleDefault-ltr');
+    await page.keyboard.type('Realizando um tweet automatizado, utilizando a ferramenta de Testes do Playwright - Demo em breve e tutorial sobre o assunto! 😎 (Link: https://playwright.dev/)');
     await page.click('div[data-testid="tweetButtonInline"]');
 
 })();


### PR DESCRIPTION
Thanks for putting together these demos.

In the tweet demo, the `page.fill` API is not working because the web page has a custom `div` element which is used for text input (and not a standard input element like `input` or `textarea`).

To work around this, we can use `page.click` to focus the element and then `page.keyboard.press` to send keyboard events to the focus element. This PR makes that change.